### PR TITLE
Add account/base.html to wrap allauth pages in site template

### DIFF
--- a/shrew/templates/account/base.html
+++ b/shrew/templates/account/base.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block title %}{% block head_title %}{% endblock %} - Code Shrew{% endblock %}
+
+{% block content %}{% endblock %}


### PR DESCRIPTION
All allauth account pages (login, signup, password reset, email confirmation, etc.) extend account/base.html. Without a custom override, they fell back to allauth's unstyled built-in base, rendering without the Code Shrew navbar, footer, or CSS.