### PR TITLE
Style all allauth account pages with Bulma

### DIFF
--- a/shrew/templates/account/email.html
+++ b/shrew/templates/account/email.html
@@ -1,0 +1,82 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load bulma_tags %}
+
+{% block head_title %}{% trans "E-mail Addresses" %}{% endblock %}
+
+{% block content %}
+<h2 class="title is-5">{% trans "E-mail Addresses" %}</h2>
+
+{% if user.emailaddress_set.all %}
+  <p class="content">{% trans "The following e-mail addresses are associated with your account:" %}</p>
+
+  <form action="{% url 'account_email' %}" class="email_list" method="post">
+    {% csrf_token %}
+
+    {% for emailaddress in user.emailaddress_set.all %}
+      <div class="field">
+        <label class="radio">
+          <input type="radio" name="email"
+            {% if emailaddress.primary or user.emailaddress_set.count == 1 %}checked{% endif %}
+            value="{{ emailaddress.email }}">
+          {{ emailaddress.email }}
+          {% if emailaddress.verified %}
+            <span class="tag is-success is-light">{% trans "Verified" %}</span>
+          {% else %}
+            <span class="tag is-warning is-light">{% trans "Unverified" %}</span>
+          {% endif %}
+          {% if emailaddress.primary %}
+            <span class="tag is-info is-light">{% trans "Primary" %}</span>
+          {% endif %}
+        </label>
+      </div>
+    {% endfor %}
+
+    <div class="field is-grouped">
+      <div class="control">
+        <button class="button is-light" type="submit" name="action_primary">{% trans "Make Primary" %}</button>
+      </div>
+      <div class="control">
+        <button class="button is-light" type="submit" name="action_send">{% trans "Re-send Verification" %}</button>
+      </div>
+      <div class="control">
+        <button class="button is-danger is-light" type="submit" name="action_remove" id="remove_email">{% trans "Remove" %}</button>
+      </div>
+    </div>
+  </form>
+{% else %}
+  <div class="message is-warning">
+    <div class="message-body">
+      {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}
+    </div>
+  </div>
+{% endif %}
+
+{% if can_add_email %}
+  <h3 class="title is-6 mt-4">{% trans "Add E-mail Address" %}</h3>
+  <form method="post" action="{% url 'account_email' %}" class="add_email">
+    {% csrf_token %}
+    {{ form|bulma }}
+    <div class="field">
+      <div class="control">
+        <button name="action_add" type="submit" class="button is-primary">{% trans "Add E-mail" %}</button>
+      </div>
+    </div>
+  </form>
+{% endif %}
+{% endblock %}
+
+{% block extra_body %}
+<script>
+(function() {
+  var message = "{% trans 'Do you really want to remove the selected e-mail address?' %}";
+  var btn = document.getElementById('remove_email');
+  if (btn) {
+    btn.addEventListener("click", function(e) {
+      if (!confirm(message)) e.preventDefault();
+    });
+  }
+})();
+</script>
+{% endblock %}

--- a/shrew/templates/account/password_change.html
+++ b/shrew/templates/account/password_change.html
@@ -1,0 +1,23 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load bulma_tags %}
+
+{% block head_title %}{% trans "Change Password" %}{% endblock %}
+
+{% block content %}
+<h2 class="title is-5 has-text-centered">{% trans "Change Password" %}</h2>
+
+<form method="POST" action="{% url 'account_change_password' %}" class="password_change">
+  {% csrf_token %}
+  {{ form|bulma }}
+  <div class="field is-grouped">
+    <div class="control">
+      <button type="submit" class="button is-success">{% trans "Change Password" %}</button>
+    </div>
+    <div class="control">
+      <a class="button is-text" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/shrew/templates/account/password_reset.html
+++ b/shrew/templates/account/password_reset.html
@@ -1,0 +1,29 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load account %}
+{% load bulma_tags %}
+
+{% block head_title %}{% trans "Password Reset" %}{% endblock %}
+
+{% block content %}
+<h2 class="title is-5 has-text-centered">{% trans "Password Reset" %}</h2>
+
+{% if user.is_authenticated %}
+  {% include "account/snippets/already_logged_in.html" %}
+{% endif %}
+
+<p class="subtitle is-6 has-text-centered has-text-grey">
+  {% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}
+</p>
+
+<form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
+  {% csrf_token %}
+  {{ form|bulma }}
+  <div class="field">
+    <div class="control">
+      <button type="submit" class="button is-success">{% trans "Reset My Password" %}</button>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/shrew/templates/account/password_reset_from_key.html
+++ b/shrew/templates/account/password_reset_from_key.html
@@ -1,0 +1,25 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load bulma_tags %}
+
+{% block head_title %}{% trans "Change Password" %}{% endblock %}
+
+{% block content %}
+{% if token_fail %}
+  <h2 class="title is-5 has-text-centered">{% trans "Bad Token" %}</h2>
+  {% url 'account_reset_password' as passwd_reset_url %}
+  <p class="has-text-centered">{% blocktrans %}The password reset link was invalid, possibly because it has already been used. Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
+{% else %}
+  <h2 class="title is-5 has-text-centered">{% trans "Change Password" %}</h2>
+  <form method="POST" action="{{ action_url }}">
+    {% csrf_token %}
+    {{ form|bulma }}
+    <div class="field">
+      <div class="control">
+        <button type="submit" class="button is-success">{% trans "Change Password" %}</button>
+      </div>
+    </div>
+  </form>
+{% endif %}
+{% endblock %}

--- a/shrew/templates/account/password_set.html
+++ b/shrew/templates/account/password_set.html
@@ -1,0 +1,20 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load bulma_tags %}
+
+{% block head_title %}{% trans "Set Password" %}{% endblock %}
+
+{% block content %}
+<h2 class="title is-5 has-text-centered">{% trans "Set Password" %}</h2>
+
+<form method="POST" action="{% url 'account_set_password' %}" class="password_set">
+  {% csrf_token %}
+  {{ form|bulma }}
+  <div class="field">
+    <div class="control">
+      <button type="submit" class="button is-success">{% trans "Set Password" %}</button>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/shrew/templates/account/signup.html
+++ b/shrew/templates/account/signup.html
@@ -1,7 +1,7 @@
 {% extends "account/base.html" %}
 
 {% load i18n %}
-{% load widget_tweaks %}
+{% load bulma_tags %}
 
 {% block head_title %}{% trans "Sign Up" %}{% endblock %}
 
@@ -12,52 +12,11 @@
     {% blocktrans %}Already have an account? <a href="{{ login_url }}">Sign in</a>.{% endblocktrans %}
   </p>
 
-  {% if form.non_field_errors %}
-    <div class="message is-danger">
-      <div class="message-body">
-        {% for error in form.non_field_errors %}
-          {{ error }}
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
-
   {% csrf_token %}
-  {% with WIDGET_ERROR_CLASS='is-danger' %}
-
-    {% for field in form %}
-      {% if field.field.widget.input_type == "checkbox" %}
-        <div class="field">
-          <label class="checkbox {% if field.errors %}has-text-danger{% endif %}">
-            {% render_field field %} {{ field.label }}
-          </label>
-          {% for error in field.errors %}
-            <p class="help is-danger">{{ error }}</p>
-          {% endfor %}
-        </div>
-      {% elif field.field.widget.input_type == "hidden" %}
-        {{ field }}
-      {% else %}
-        <div class="field">
-          <label class="label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-          <div class="control">
-            {% render_field field class+="input" %}
-          </div>
-          {% if field.help_text %}
-            <p class="help">{{ field.help_text }}</p>
-          {% endif %}
-          {% for error in field.errors %}
-            <p class="help is-danger">{{ error }}</p>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endfor %}
-
-    {% if redirect_field_value %}
-      <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-    {% endif %}
-
-  {% endwith %}
+  {{ form|bulma }}
+  {% if redirect_field_value %}
+    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
 
   <div class="field">
     <div class="control">


### PR DESCRIPTION
Allauth 0.54 replaced account/base.html with a standalone unstyled HTML page (older 0.36 versions just did {% extends 'base.html' %}). This commit overrides the form-bearing account pages so they render fields through the project's existing {{ form|bulma }} filter, matching the style used elsewhere (socialaccount/signup, contact form).