### PR TITLE
Allow same-origin iframe embedding of the editor

### DIFF
--- a/shrew/apps/creations/views.py
+++ b/shrew/apps/creations/views.py
@@ -55,6 +55,7 @@ class InterpreterSandboxView(View):
         return response
 
 
+@method_decorator(xframe_options_sameorigin, name='dispatch')
 @method_decorator(ensure_csrf_cookie, name='dispatch')
 class EditorView(View):
     DEFAULT_CODE = 'Circle()'

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -167,3 +167,15 @@ class DeprecatedSettingsTests(TestCase):
         from django.conf import settings
         # We removed NOCAPTCHA = True; django-recaptcha 3.x removed support for it.
         self.assertFalse(hasattr(settings, 'NOCAPTCHA'))
+
+
+class IframeEmbedTests(TestCase):
+    """The editor must be embeddable on shrew.app via the playground tag."""
+
+    def test_editor_allows_same_origin_framing(self):
+        # Django 3.0+ defaults X_FRAME_OPTIONS to 'DENY'. The editor must
+        # opt back in to SAMEORIGIN so the {{ value|shrew_embed }} iframe
+        # works on shrew.app itself.
+        response = self.client.get(reverse('editor'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get('X-Frame-Options'), 'SAMEORIGIN')


### PR DESCRIPTION
Django 3.0 changed the default X_FRAME_OPTIONS from 'SAMEORIGIN' to 'DENY'. As a result, the embedded-playground feature (the {{ value|shrew_embed }} template tag, used on page content) started hitting 'Refused to display ... in a frame because it set X-Frame- Options to deny' on shrew.app itself.

Decorate EditorView with xframe_options_sameorigin so it can be framed from the same origin, matching the existing pattern on InterpreterSandboxView. Adds a regression test.